### PR TITLE
[0.7.1] Fix import error from leftover code

### DIFF
--- a/handler/__init__.py
+++ b/handler/__init__.py
@@ -21,7 +21,7 @@ Should there be a need for contact the electronic mail
 `handler <at> gabrielfontenelle.com` can be used.
 """
 
-from .file import BaseFile, File, ContentFile, StreamFile, DownloadFile
+from .file import BaseFile, File, ContentFile, StreamFile
 from .exception import (
     ImproperlyConfiguredFile,
     NoInternalContentError,


### PR DESCRIPTION
This PR fix a import error from a leftover code that resulted from moving `DownloadFile` to another project.