### PR TITLE
refactor: Make use of OOP to avoid using ifs in FileContent.

### DIFF
--- a/filejacket/file/__init__.py
+++ b/filejacket/file/__init__.py
@@ -710,7 +710,7 @@ class BaseFile:
         Method to return a list of Pipelines available to the current object. Pipelines are instances that inherent
         from Pipeline class.
 
-        For this method to work with BaseFile overriden classes those need to implement the method __serialize__
+        For this method to work with BaseFile overridden classes need to implement the method __serialize__
         in it and its attributes (when those are custom classes).
         """
 

--- a/filejacket/pipelines/extractor/package.py
+++ b/filejacket/pipelines/extractor/package.py
@@ -265,7 +265,7 @@ class PSDLayersFromPackageExtractor(PackageExtractor):
     @classmethod
     def decompress(cls, file_object: BaseFile, overrider: bool, **kwargs: Any) -> bool:
         """
-        Method to uncompress the content from a file_object.
+        Method to decompress the content from a file_object.
         """
         try:
             # We need to create the directory because there is no extractor for handling PSD.


### PR DESCRIPTION
## Description

this PR refactors how buffer are instantiate and verified to avoid using ifs in some parts of FileContent.

Added the missing docstring for specialized serializer. 

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in PR (and tests are passing)
- [ ] Updated README and/or documentation, if necessary

Thanks for contributing!
